### PR TITLE
Check for ellekit and libEllekit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Update
-This terminal command also has the same effect, which is better as it doesn't require dylib injection so it works with SIP
+This terminal command also has the same effect, however you will lose the new Spotlight.
 
 ``` 
 sudo mkdir -p /Library/Preferences/FeatureFlags/Domain

--- a/README.md
+++ b/README.md
@@ -29,8 +29,13 @@ https://github.com/doraorak/Dylinject
 # Usage 
 inject the dylib to dock
 
-# Building
-using www.theos.dev -> `make clean package`
+# Building using Theos
+
+The iOS frameworks don't provide IOKit headers so you'll need to use this to use the macOS ones.
+
+`mv $THEOS/vendor/include/{IOKit,IOKit_iOS}`
+
+`make clean package`
 
 # Limitations
 clicking launchpad icon again doesn't exit launchpad.

--- a/Tweak.x
+++ b/Tweak.x
@@ -15,15 +15,22 @@ bool _os_feature_enabled_impl_hook(char* a, char* b){
     return orig(a, b);
 }
 
-%ctor{
-   void* ffh = dlopen("/usr/lib/system/libsystem_featureflags.dylib", RTLD_NOW);
-   void* handle = dlopen("/Library/TweakInject/libEllekit.dylib", RTLD_NOW);
+%ctor {
+    void* ffh = dlopen("/usr/lib/system/libsystem_featureflags.dylib", RTLD_NOW);
+
+    void* handle = dlopen("/Library/TweakInject/ellekit.dylib", RTLD_NOW);
+    if (!handle) {
+        handle = dlopen("/Library/TweakInject/libEllekit.dylib", RTLD_NOW);
+    }
+
+    if (!handle) {
+        os_log(OS_LOG_DEFAULT, "[tweak][launchbad] Failed to load Ellekit dylib");
+        return;
+    }
 
     _MSHookFunction = dlsym(handle, "MSHookFunction");
 
     _MSHookFunction(dlsym(ffh, "_os_feature_enabled_impl"), _os_feature_enabled_impl_hook, &orig);
 
     os_log(OS_LOG_DEFAULT, "[tweak][launchbad] end");
-
 }
-

--- a/launchbad.plist
+++ b/launchbad.plist
@@ -1,1 +1,13 @@
-{ Filter = { Bundles = ( "com.apple.dock" ); }; }
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Filter</key>
+    <dict>
+        <key>Bundles</key>
+        <array>
+            <string>com.apple.dock</string>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This ensures the tweak checks both places for Ellekit, just in case it varies between installations.